### PR TITLE
Minor Refactoring for VsTemplateCreator

### DIFF
--- a/src/localdrive.go
+++ b/src/localdrive.go
@@ -30,13 +30,11 @@ func purgeExistingGitDirectory() bool {
 }
 
 func renameRepo(templateName string, newName string) bool {
-
 	//if err := os.Rename("VSCodeGoLangStarterTemplate", newName); err != nil {
 	if err := os.Rename(templateName, newName); err != nil {
 		log("failed to rename")
 		log(err.Error())
 		return false
 	}
-
 	return true
 }

--- a/src/localdrive.go
+++ b/src/localdrive.go
@@ -1,6 +1,9 @@
 package main
 
-import "os"
+import (
+	"os"
+	"strings"
+)
 
 /*
 remove current cached directory (in case previous operations failed)
@@ -21,8 +24,9 @@ func deleteExistingRustDirectory() bool {
 	return true
 }
 
-func purgeExistingGitDirectory() bool {
-	if err := os.RemoveAll("VSCodeGoLangStarterTemplate/.git"); err != nil {
+func purgeExistingGitDirectory(newProjectName string) bool {
+	projPath := strings.Join([]string{newProjectName, "/.git"}, "")
+	if err := os.RemoveAll(projPath); err != nil {
 		log(err.Error())
 		return false
 	}

--- a/src/main.go
+++ b/src/main.go
@@ -44,7 +44,7 @@ func main() {
 
 		if isAlphanumeric(newProjectName) {
 			var projectType = strings.ToLower(args[2])
-			createProject[projectType](newProjectName)
+			createProject[projectType](newProjectName,projectType)
 		} else {
 			printHelp()
 		}

--- a/src/templatemod.go
+++ b/src/templatemod.go
@@ -27,21 +27,22 @@ func setupMappedFunctions() map[string]sub {
 	return mappedFunctions
 }
 
-func pullTemplateRepo(projectType string) bool {
+func pullTemplateRepo(projectType string,  newProjectName string) bool {
 	var cmd = "git"
 	var args []string
+
 	switch projectType {
-	case "golang":
-		args = []string{"clone", "https://github.com/RoteErde/VSCodeGoLangStarterTemplate"}
-	case "rust":
-		args = []string{"clone", "https://github.com/RoteErde/RustVSCodeTemplate"}
-	case"ts":
-		args = []string{"clone", "https://github.com/rebooting/TypeScriptVSCodeTemplate"}
-	case"js":
-		args = []string{"clone", "https://github.com/rebooting/JsWebDeVSCodeTemplate"}
-	default:
-		fmt.Println("No valid repository specify")
-		return false
+		case "golang":
+			args = []string{"clone", "https://github.com/RoteErde/VSCodeGoLangStarterTemplate", newProjectName}
+		case "rust":
+			args = []string{"clone", "https://github.com/RoteErde/RustVSCodeTemplate", newProjectName}
+		case"ts":
+			args = []string{"clone", "https://github.com/rebooting/TypeScriptVSCodeTemplate", newProjectName}
+		case"js":
+			args = []string{"clone", "https://github.com/rebooting/JsWebDeVSCodeTemplate", newProjectName}
+		default:
+			fmt.Println("No valid repository specify")
+			return false
 	}
 
 	if cmdout, err := exec.Command(cmd, args...).Output(); err != nil {
@@ -55,14 +56,12 @@ func pullTemplateRepo(projectType string) bool {
 func createRustProject(newProjectName string, projectType string) {
 	deleteExistingRustDirectory()
 	log("cloning github template")
-	if pullTemplateRepo(projectType) {
+	if pullTemplateRepo(projectType,  newProjectName) {
 		log("cloning done, renaming")
 		//allow a pause as I've encountered directory lock in windows
 		time.Sleep(time.Millisecond * 200)
 		log("removing git")
 		purgeExistingGitDirectory()
-		renameRepo("RustVSCodeTemplate", newProjectName)
-		log("renaming done")
 	} else {
 		log("error occured")
 	}
@@ -72,14 +71,12 @@ func createRustProject(newProjectName string, projectType string) {
 func createGoProject(newProjectName string, projectType string) {
 	deleteExistingGoDirectory()
 	log("cloning github template")
-	if pullTemplateRepo(projectType) {
+	if pullTemplateRepo(projectType, newProjectName) {
 		log("cloning done, renaming")
 		//allow a pause as I've encountered directory lock in windows
 		time.Sleep(time.Millisecond * 200)
 		log("removing git")
 		purgeExistingGitDirectory()
-		renameRepo("VSCodeGoLangStarterTemplate", newProjectName)
-		log("renaming done")
 	} else {
 		log("error occured")
 	}
@@ -89,14 +86,12 @@ func createGoProject(newProjectName string, projectType string) {
 func createTypeScriptProject(newProjectName string,  projectType string) {
 	deleteExistingGoDirectory()
 	log("cloning github template")
-	if pullTemplateRepo(projectType) {
+	if pullTemplateRepo(projectType, newProjectName) {
 		log("cloning done, renaming")
 		//allow a pause as I've encountered directory lock in windows
 		time.Sleep(time.Millisecond * 200)
 		log("removing git")
 		purgeExistingGitDirectory()
-		renameRepo("TypeScriptVSCodeTemplate", newProjectName)
-		log("renaming done")
 	} else {
 		log("error occured")
 	}
@@ -106,14 +101,12 @@ func createTypeScriptProject(newProjectName string,  projectType string) {
 func createJavaScriptProject(newProjectName string, projectType string) {
 	deleteExistingGoDirectory()
 	log("cloning github template")
-	if pullTemplateRepo(projectType) {
+	if pullTemplateRepo(projectType, newProjectName) {
 		log("cloning done, renaming")
 		//allow a pause as I've encountered directory lock in windows
 		time.Sleep(time.Millisecond * 200)
 		log("removing git")
 		purgeExistingGitDirectory()
-		renameRepo("JsWebDeVSCodeTemplate", newProjectName)
-		log("renaming done")
 	} else {
 		log("error occured")
 	}

--- a/src/templatemod.go
+++ b/src/templatemod.go
@@ -1,9 +1,9 @@
 package main
 
 import (
+	"fmt"
 	"os/exec"
 	"time"
-	"fmt"
 )
 
 /**
@@ -13,7 +13,7 @@ Logic for cloning
 */
 
 // function prototype for map
-type sub func(string,string)
+type sub func(string, string)
 
 func setupMappedFunctions() map[string]sub {
 	mappedFunctions := map[string]sub{
@@ -27,22 +27,22 @@ func setupMappedFunctions() map[string]sub {
 	return mappedFunctions
 }
 
-func pullTemplateRepo(projectType string,  newProjectName string) bool {
+func pullTemplateRepo(projectType string, newProjectName string) bool {
 	var cmd = "git"
 	var args []string
 
 	switch projectType {
-		case "golang":
-			args = []string{"clone", "https://github.com/RoteErde/VSCodeGoLangStarterTemplate", newProjectName}
-		case "rust":
-			args = []string{"clone", "https://github.com/RoteErde/RustVSCodeTemplate", newProjectName}
-		case"ts":
-			args = []string{"clone", "https://github.com/rebooting/TypeScriptVSCodeTemplate", newProjectName}
-		case"js":
-			args = []string{"clone", "https://github.com/rebooting/JsWebDeVSCodeTemplate", newProjectName}
-		default:
-			fmt.Println("No valid repository specify")
-			return false
+	case "golang":
+		args = []string{"clone", "https://github.com/RoteErde/VSCodeGoLangStarterTemplate", newProjectName}
+	case "rust":
+		args = []string{"clone", "https://github.com/RoteErde/RustVSCodeTemplate", newProjectName}
+	case "ts":
+		args = []string{"clone", "https://github.com/rebooting/TypeScriptVSCodeTemplate", newProjectName}
+	case "js":
+		args = []string{"clone", "https://github.com/rebooting/JsWebDeVSCodeTemplate", newProjectName}
+	default:
+		fmt.Println("No valid repository specify")
+		return false
 	}
 
 	if cmdout, err := exec.Command(cmd, args...).Output(); err != nil {
@@ -56,12 +56,12 @@ func pullTemplateRepo(projectType string,  newProjectName string) bool {
 func createRustProject(newProjectName string, projectType string) {
 	deleteExistingRustDirectory()
 	log("cloning github template")
-	if pullTemplateRepo(projectType,  newProjectName) {
+	if pullTemplateRepo(projectType, newProjectName) {
 		log("cloning done, renaming")
 		//allow a pause as I've encountered directory lock in windows
 		time.Sleep(time.Millisecond * 200)
 		log("removing git")
-		purgeExistingGitDirectory()
+		purgeExistingGitDirectory(newProjectName)
 	} else {
 		log("error occured")
 	}
@@ -76,14 +76,14 @@ func createGoProject(newProjectName string, projectType string) {
 		//allow a pause as I've encountered directory lock in windows
 		time.Sleep(time.Millisecond * 200)
 		log("removing git")
-		purgeExistingGitDirectory()
+		purgeExistingGitDirectory(newProjectName)
 	} else {
 		log("error occured")
 	}
 
 }
 
-func createTypeScriptProject(newProjectName string,  projectType string) {
+func createTypeScriptProject(newProjectName string, projectType string) {
 	deleteExistingGoDirectory()
 	log("cloning github template")
 	if pullTemplateRepo(projectType, newProjectName) {
@@ -91,11 +91,10 @@ func createTypeScriptProject(newProjectName string,  projectType string) {
 		//allow a pause as I've encountered directory lock in windows
 		time.Sleep(time.Millisecond * 200)
 		log("removing git")
-		purgeExistingGitDirectory()
+		purgeExistingGitDirectory(newProjectName)
 	} else {
 		log("error occured")
 	}
-
 }
 
 func createJavaScriptProject(newProjectName string, projectType string) {
@@ -106,7 +105,7 @@ func createJavaScriptProject(newProjectName string, projectType string) {
 		//allow a pause as I've encountered directory lock in windows
 		time.Sleep(time.Millisecond * 200)
 		log("removing git")
-		purgeExistingGitDirectory()
+		purgeExistingGitDirectory(newProjectName)
 	} else {
 		log("error occured")
 	}

--- a/src/templatemod.go
+++ b/src/templatemod.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os/exec"
 	"time"
+	"fmt"
 )
 
 /**
@@ -12,7 +13,7 @@ Logic for cloning
 */
 
 // function prototype for map
-type sub func(string)
+type sub func(string,string)
 
 func setupMappedFunctions() map[string]sub {
 	mappedFunctions := map[string]sub{
@@ -26,10 +27,35 @@ func setupMappedFunctions() map[string]sub {
 	return mappedFunctions
 }
 
-func createRustProject(newProjectName string) {
+func pullTemplateRepo(projectType string) bool {
+	var cmd = "git"
+	var args []string
+	switch projectType {
+	case "golang":
+		args = []string{"clone", "https://github.com/RoteErde/VSCodeGoLangStarterTemplate"}
+	case "rust":
+		args = []string{"clone", "https://github.com/RoteErde/RustVSCodeTemplate"}
+	case"ts":
+		args = []string{"clone", "https://github.com/rebooting/TypeScriptVSCodeTemplate"}
+	case"js":
+		args = []string{"clone", "https://github.com/rebooting/JsWebDeVSCodeTemplate"}
+	default:
+		fmt.Println("No valid repository specify")
+		return false
+	}
+
+	if cmdout, err := exec.Command(cmd, args...).Output(); err != nil {
+		log(string(cmdout))
+		log(err.Error())
+		return false
+	}
+	return true
+}
+
+func createRustProject(newProjectName string, projectType string) {
 	deleteExistingRustDirectory()
 	log("cloning github template")
-	if pullRustRepo() {
+	if pullTemplateRepo(projectType) {
 		log("cloning done, renaming")
 		//allow a pause as I've encountered directory lock in windows
 		time.Sleep(time.Millisecond * 200)
@@ -43,22 +69,10 @@ func createRustProject(newProjectName string) {
 
 }
 
-func pullRustRepo() bool {
-	var cmd = "git"
-	var args = []string{"clone", "https://github.com/RoteErde/RustVSCodeTemplate"}
-	if cmdout, err := exec.Command(cmd, args...).Output(); err != nil {
-		log(string(cmdout))
-		log(err.Error())
-		return false
-	}
-
-	return true
-}
-
-func createGoProject(newProjectName string) {
+func createGoProject(newProjectName string, projectType string) {
 	deleteExistingGoDirectory()
 	log("cloning github template")
-	if pullGoRepo() {
+	if pullTemplateRepo(projectType) {
 		log("cloning done, renaming")
 		//allow a pause as I've encountered directory lock in windows
 		time.Sleep(time.Millisecond * 200)
@@ -72,22 +86,10 @@ func createGoProject(newProjectName string) {
 
 }
 
-func pullGoRepo() bool {
-	var cmd = "git"
-	var args = []string{"clone", "https://github.com/RoteErde/VSCodeGoLangStarterTemplate"}
-	if cmdout, err := exec.Command(cmd, args...).Output(); err != nil {
-		log(string(cmdout))
-		log(err.Error())
-		return false
-	}
-
-	return true
-}
-
-func createTypeScriptProject(newProjectName string) {
+func createTypeScriptProject(newProjectName string,  projectType string) {
 	deleteExistingGoDirectory()
 	log("cloning github template")
-	if pullTSRepo() {
+	if pullTemplateRepo(projectType) {
 		log("cloning done, renaming")
 		//allow a pause as I've encountered directory lock in windows
 		time.Sleep(time.Millisecond * 200)
@@ -101,22 +103,10 @@ func createTypeScriptProject(newProjectName string) {
 
 }
 
-func pullTSRepo() bool {
-	var cmd = "git"
-	var args = []string{"clone", "https://github.com/rebooting/TypeScriptVSCodeTemplate"}
-	if cmdout, err := exec.Command(cmd, args...).Output(); err != nil {
-		log(string(cmdout))
-		log(err.Error())
-		return false
-	}
-
-	return true
-}
-
-func createJavaScriptProject(newProjectName string) {
+func createJavaScriptProject(newProjectName string, projectType string) {
 	deleteExistingGoDirectory()
 	log("cloning github template")
-	if pullJSRepo() {
+	if pullTemplateRepo(projectType) {
 		log("cloning done, renaming")
 		//allow a pause as I've encountered directory lock in windows
 		time.Sleep(time.Millisecond * 200)
@@ -128,16 +118,4 @@ func createJavaScriptProject(newProjectName string) {
 		log("error occured")
 	}
 
-}
-
-func pullJSRepo() bool {
-	var cmd = "git"
-	var args = []string{"clone", "https://github.com/rebooting/JsWebDeVSCodeTemplate"}
-	if cmdout, err := exec.Command(cmd, args...).Output(); err != nil {
-		log(string(cmdout))
-		log(err.Error())
-		return false
-	}
-
-	return true
 }


### PR DESCRIPTION
Some minor refactoring

1) Include switch statement to pull the correct code template
2) Update git meta file purging to the newly cloned project directory
3) Update the git command to the following 

`git clone <<Repo URL>> <<projectName>>`

**projectName** = The name of a new directory to clone into
As such, the  program  wouldn't need to make another step to rename the project directory